### PR TITLE
Setup ::   Fixed system requirement check result text if requirement is not met 

### DIFF
--- a/setup/controllers/RequirementsController.php
+++ b/setup/controllers/RequirementsController.php
@@ -73,6 +73,10 @@ class RequirementsController extends Setup_Controller_Abstract
             $status = $status ? self::REQUIREMENT_OK : self::REQUIREMENT_ERROR;
         }
 
+        if ($status !== self::REQUIREMENT_OK && $value === 'installed') {
+            $value = 'not installed';
+        }
+
         $this->_requirements[$requirement] = array(
             'status' => $status,
             'value'  => $value,


### PR DESCRIPTION
The oTranCe setup routine prints wrong status text for missing and mandatory extensions or functions.
![requirement_check_bug](https://f.cloud.github.com/assets/149483/11607/e17f06e2-455a-11e2-8b7b-654211b5c737.png)
Maybe you want to fix this minor issue in the origin methods like RequirementsController::_checkExtension() by passing the $value-parameter with concrete status informations but I think this pull request should be an appropriate fix.
