### PR TITLE
Refactor CSV Importer to support multi line content

### DIFF
--- a/modules/library/Import/Csv.php
+++ b/modules/library/Import/Csv.php
@@ -111,7 +111,6 @@ class Module_Import_Csv implements Msd_Import_Interface
             if (($inputValue{0} == "'" && $inputValue{$inputLength - 1} == "'")
                 || ($inputValue{0} == "\"" && $inputValue{$inputLength - 1} == "\"")
             ) {
-                echo "clean";
                 $inputValue = substr($inputValue, 1, $inputLength - 2);
                 return $inputValue;
             }

--- a/modules/library/Import/Csv.php
+++ b/modules/library/Import/Csv.php
@@ -64,11 +64,11 @@ class Module_Import_Csv implements Msd_Import_Interface
         unset($data);
         $this->_extractedData = array();
 
-        $csvArray = str_getcsv($this->_data, "\n"); //parse the rows
+        $fp = fopen('php://temp', 'r+');
 
-
-        foreach ($csvArray AS $row){
-            $currentLine = str_getcsv($row, $this->_separator);
+        fwrite($fp, $this->_data);
+        rewind($fp);
+        while (($currentLine = fgetcsv($fp, 0, $this->_separator)) !== FALSE) {
             $currentKey = trim($currentLine[0]);
 
             if ($currentKey == '' || !isset($currentLine[1])) {

--- a/modules/library/Import/Csv.php
+++ b/modules/library/Import/Csv.php
@@ -60,27 +60,25 @@ class Module_Import_Csv implements Msd_Import_Interface
      */
     public function extract($data)
     {
-        $this->_data = $data;
+        $this->_data = str_replace("\xEF\xBB\xBF",'',$data); //remove bom
         unset($data);
         $this->_extractedData = array();
 
-        $this->_lines = explode("\n", $this->_data);
-        $lines_count  = count($this->_lines);
+        $csvArray = str_getcsv($this->_data, "\n"); //parse the rows
 
-        for ($i = 0; $i < $lines_count; $i++) {
-            $currentLine = explode($this->_separator, $this->_lines[$i], 2);
 
+        foreach ($csvArray AS $row){
+            $currentLine = str_getcsv($row, $this->_separator);
             $currentKey = trim($currentLine[0]);
+
             if ($currentKey == '' || !isset($currentLine[1])) {
                 continue;
             }
-            $currentValue = trim($currentLine[1]);
-            $dataLength = strlen($currentValue);
 
-            if (($currentValue{0} == "'" && $currentValue{$dataLength -1} == "'")
-                || ($currentValue{0} == "\"" && $currentValue{$dataLength -1} == "\"")) {
-                $currentValue = substr($currentValue, 1, $dataLength - 2);
-            }
+            $currentValue = trim($currentLine[1]);
+            $currentKey = $this->cleanInput($currentKey);
+
+            $currentValue = $this->cleanInput($currentValue);
 
             $this->_extractedData[$currentKey] = $currentValue;
         }
@@ -98,5 +96,26 @@ class Module_Import_Csv implements Msd_Import_Interface
     public function getInfo(Zend_View_Interface $view)
     {
         return $view->render('csv.phtml');
+    }
+
+    /**
+     * removes double " and single ' enclosure
+     *
+     * @param $inputValue
+     * @return string
+     */
+    protected function cleanInput($inputValue)
+    {
+        $inputLength = strlen(trim($inputValue));
+        if ($inputLength > 0){
+            if (($inputValue{0} == "'" && $inputValue{$inputLength - 1} == "'")
+                || ($inputValue{0} == "\"" && $inputValue{$inputLength - 1} == "\"")
+            ) {
+                echo "clean";
+                $inputValue = substr($inputValue, 1, $inputLength - 2);
+                return $inputValue;
+            }
+        }
+        return $inputValue;
     }
 }


### PR DESCRIPTION
## Problem 

The current CSV importer does not support multi line content.
Currently multiline content get's discarded after the first line.

![csv_multilang](https://cloud.githubusercontent.com/assets/2870718/17030018/f357f2c2-4f6d-11e6-835e-ac7f5d7eb44b.png)

## The PR solve
1. remove enclosures from key 
2. **handle multi line CSV by using native parse functions (fgetcsv)**
3. remove BOM from CSV content

Result:

![csv_multilang](https://cloud.githubusercontent.com/assets/2870718/17029972/bdda1756-4f6d-11e6-85cb-9a56c7ffa7f9.png)

