### PR TITLE
Mark keys as optional

### DIFF
--- a/application/controllers/EntriesController.php
+++ b/application/controllers/EntriesController.php
@@ -125,6 +125,11 @@ class EntriesController extends OtranceController
             $this->view->showLanguages,
             $this->view->hits
         );
+
+        foreach ($this->view->hits as $k => $hit) {
+            $key = $this->_entriesModel->getKeyById($hit['id']);
+            $this->view->hits[$k]['clf'] = $key['clf'];
+        }
     }
 
     /**
@@ -216,7 +221,7 @@ class EntriesController extends OtranceController
             $this->view->translatable = array_keys($translationService->getLocaleMap());
         }
         $this->view->useTranslationService  = $translationServiceActive;
-        $this->view->translationServiceName = $translationConfig['selectedService'];
+        $this->view->translationServiceName = (isset($translationConfig['selectedService']) ? $translationConfig['selectedService'] : null);
 
         $this->view->skipKeysOffsets = $this->_dynamicConfig->getParam('entries.skippedKeys', array());
         $this->_setReferrer();
@@ -493,6 +498,13 @@ class EntriesController extends OtranceController
     private function _saveEntries($ignoreSmallChange = false)
     {
         $params = $this->getRequest()->getParams();
+
+        $nid = (isset($params['clf'])) ? true : false;
+
+        if(isset($params['id'])) {
+            $this->_entriesModel->setOnlyCertainLanguageFlag($params['id'], $nid);
+        }
+
         $values = array();
         foreach ($params as $name => $val) {
             if (substr($name, 0, 5) == 'edit-') {

--- a/application/language/de/lang.php
+++ b/application/language/de/lang.php
@@ -448,5 +448,7 @@ Nur zugeordnete Sprachen können vom Dienst übersetzt werden. Bearbeiten Sie di
 'L_ZEND_ID_STRING_LENGTH_INVALID' => 'Die Eingabe ist ungültig.',
 'L_ZEND_ID_STRING_LENGTH_TOO_LONG' => 'Die Eingabe ist zu lang.',
 'L_ZEND_ID_STRING_LENGTH_TOO_SHORT' => 'Die Eingabe ist zu kurz.',
+'L_CLF' => 'Nur für bestimmte Sprache',
+    'L_CLF_LONG' => 'Dieser Schlüssel ist nur für eine Sprache notwendig (Übersetzung nicht nötig)',
 );
 return $lang;

--- a/application/language/de/lang.php
+++ b/application/language/de/lang.php
@@ -448,7 +448,7 @@ Nur zugeordnete Sprachen können vom Dienst übersetzt werden. Bearbeiten Sie di
 'L_ZEND_ID_STRING_LENGTH_INVALID' => 'Die Eingabe ist ungültig.',
 'L_ZEND_ID_STRING_LENGTH_TOO_LONG' => 'Die Eingabe ist zu lang.',
 'L_ZEND_ID_STRING_LENGTH_TOO_SHORT' => 'Die Eingabe ist zu kurz.',
-'L_CLF' => 'Nur für bestimmte Sprache',
-    'L_CLF_LONG' => 'Dieser Schlüssel ist nur für eine Sprache notwendig (Übersetzung nicht nötig)',
+'L_OPTIONAL_TRANSLATION' => 'Der Key muss nicht in diese Sprache übersetzt werden.',
+'L_OPTIONAL_TRANSLATION_LONG_DESC' => 'Graue Felder bedürfen keiner Übersetzung.',
 );
 return $lang;

--- a/application/language/en/lang.php
+++ b/application/language/en/lang.php
@@ -450,5 +450,7 @@ Only mapped languages can be translated by the external service. Edit the langua
 'L_ZEND_ID_STRING_LENGTH_INVALID' => 'Invalid input.',
 'L_ZEND_ID_STRING_LENGTH_TOO_LONG' => 'The provided input is too long.',
 'L_ZEND_ID_STRING_LENGTH_TOO_SHORT' => 'The provided input is too short.',
+'L_CLF' => 'Only for certain language',
+'L_CLF_LONG' => 'This key is only for one language necessary (Translation no necessary)',
 );
 return $lang;

--- a/application/language/en/lang.php
+++ b/application/language/en/lang.php
@@ -450,7 +450,7 @@ Only mapped languages can be translated by the external service. Edit the langua
 'L_ZEND_ID_STRING_LENGTH_INVALID' => 'Invalid input.',
 'L_ZEND_ID_STRING_LENGTH_TOO_LONG' => 'The provided input is too long.',
 'L_ZEND_ID_STRING_LENGTH_TOO_SHORT' => 'The provided input is too short.',
-'L_CLF' => 'Only for certain language',
-'L_CLF_LONG' => 'This key is only for one language necessary (Translation no necessary)',
+'L_OPTIONAL_TRANSLATION' => 'The key doesn\'t need to be translated to this language.',
+'L_OPTIONAL_TRANSLATION_LONG_DESC' => 'For grey fields no translation is needed.',
 );
 return $lang;

--- a/application/models/LanguageEntries.php
+++ b/application/models/LanguageEntries.php
@@ -128,6 +128,8 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
         $pattern
                            =
             "SELECT count(*) as anzahl, SUM(`needs_update`) as review FROM `" . $this->_tableTranslations . "` "
+            . " INNER JOIN `" . $this->_tableKeys . "` "
+            . "ON (`" . $this->_tableTranslations . "`.`key_id` = `" . $this->_tableKeys . "`.`id` AND `" . $this->_tableKeys . "`.clf = 0) "
             . " WHERE `lang_id`= %d";
         foreach ($languageIds as $val) {
             $langId                        = $val['id'];
@@ -160,7 +162,7 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
      */
     public function getNrOfLanguageVars()
     {
-        $sql = 'SELECT count(*) as `nrOfLanguageVars` FROM `' . $this->_tableKeys . '`';
+        $sql = 'SELECT count(*) as `nrOfLanguageVars` FROM `' . $this->_tableKeys . '` WHERE `clf` = 0';
         $res = $this->_dbo->query($sql, Msd_Db::ARRAY_OBJECT, true);
 
         return isset($res[0]->nrOfLanguageVars) ? $res[0]->nrOfLanguageVars : 0;
@@ -814,6 +816,22 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
             . "WHERE `lang_id`='$languageId' AND `key_id`='$keyId';";
 
         return (bool)$this->_dbo->query($sql, Msd_Db::SIMPLE);
+    }
+
+    /**
+     * Update the flag for certain language only
+     *
+     * @param int $keyId        Id of the key.
+     * @param bool $value       Value of ind field.
+     *
+     * @return bool
+     */
+    public function setOnlyCertainLanguageFlag($keyId, $value) {
+            $sql = "UPDATE `{$this->_database}`.`{$this->_tableKeys}` "
+                    . "SET `clf`='" . (int) $value . "' "
+                    . "WHERE `id`='$keyId';";
+
+            return (bool)$this->_dbo->query($sql, Msd_Db::SIMPLE);
     }
 
 }

--- a/application/models/LanguageEntries.php
+++ b/application/models/LanguageEntries.php
@@ -32,6 +32,13 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
     private $_tableTranslations;
 
     /**
+     * Database table containing optional translation keys
+     *
+     * @var string
+     */
+    private $_tableOptionalTranslations;
+
+    /**
      * Database table containing languages
      *
      * @var string
@@ -68,6 +75,7 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
     {
         $this->_tableLanguages     = $this->_tablePrefix . 'languages';
         $this->_tableTranslations  = $this->_tablePrefix . 'translations';
+        $this->_tableOptionalTranslations  = $this->_tablePrefix . 'optional_translations';
         $this->_tableKeys          = $this->_tablePrefix . 'keys';
         $this->_tableFileTemplates = $this->_tablePrefix . 'filetemplates';
     }
@@ -125,17 +133,32 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
         $ret               = array();
         $totalLanguageVars = $this->getNrOfLanguageVars();
         $translators       = $this->getTranslators();
-        $pattern
-                           =
-            "SELECT count(*) as anzahl, SUM(`needs_update`) as review FROM `" . $this->_tableTranslations . "` "
+
+        $optionalLanguageCount = array();
+        $optionalTranslations = $this->getOptionalTranslations(null, array_keys($languageIds));
+
+        foreach($optionalTranslations as $optionalTranslationKeys) {
+            foreach($optionalTranslationKeys as $optionalTranslationLanguage => $check) {
+                $optionalLanguageCount[$optionalTranslationLanguage]++;
+            }
+        }
+
+        $pattern =
+            "SELECT count(*) as anzahl, "
+            . " SUM(`needs_update`) as review FROM `" . $this->_tableTranslations . "` "
             . " INNER JOIN `" . $this->_tableKeys . "` "
-            . "ON (`" . $this->_tableTranslations . "`.`key_id` = `" . $this->_tableKeys . "`.`id` AND `" . $this->_tableKeys . "`.clf = 0) "
-            . " WHERE `lang_id`= %d";
+            . "ON (`" . $this->_tableTranslations . "`.`key_id` = `" . $this->_tableKeys . "`.`id`)"
+            . " LEFT JOIN `" . $this->_tableOptionalTranslations . "` "
+            . "ON (`" . $this->_tableTranslations . "`.`lang_id` = `" . $this->_tableOptionalTranslations . "`.`lang_id` AND `" . $this->_tableKeys . "`.`id` = `" . $this->_tableOptionalTranslations . "`.`key_id`)"
+            . " WHERE `" . $this->_tableTranslations . "`.`lang_id` = %d "
+            . " AND `" . $this->_tableTranslations . "`.`text` IS NOT NULL AND `" . $this->_tableTranslations . "`.`text` != ''"
+            . " AND `" . $this->_tableOptionalTranslations . "`.`lang_id` IS NULL";
         foreach ($languageIds as $val) {
             $langId                        = $val['id'];
             $sql                           = sprintf($pattern, (int)$val['id']);
             $res                           = $this->_dbo->query($sql, Msd_Db::ARRAY_ASSOC, true);
-            $translated                    = $res[0]['anzahl'];
+            $optionalTranslation           = (isset($optionalLanguageCount[$langId])) ? $optionalLanguageCount[$langId] : 0;
+            $translated                    = $res[0]['anzahl'] + $optionalTranslation;
             $ret[$langId]                  = array();
             $ret[$langId]['languageId']    = $langId;
             $ret[$langId]['notTranslated'] = $totalLanguageVars - $translated;
@@ -162,7 +185,7 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
      */
     public function getNrOfLanguageVars()
     {
-        $sql = 'SELECT count(*) as `nrOfLanguageVars` FROM `' . $this->_tableKeys . '` WHERE `clf` = 0';
+        $sql = 'SELECT count(*) as `nrOfLanguageVars` FROM `' . $this->_tableKeys . '`';
         $res = $this->_dbo->query($sql, Msd_Db::ARRAY_OBJECT, true);
 
         return isset($res[0]->nrOfLanguageVars) ? $res[0]->nrOfLanguageVars : 0;
@@ -310,7 +333,10 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
             // we are looking for a specific language
             // Add the language condition to the JOIN, not to the WHERE clause.
             $sql .= ' AND t.`lang_id`=' . $languageId
-                . ' WHERE (t.`text`=\'\' OR t.`text` IS NULL OR t.`needs_update`=1)';
+                . ' LEFT JOIN `' . $this->_tableOptionalTranslations . '` o'
+                . ' ON o.`key_id` = k.`id` AND o.`lang_id` = ' . $languageId
+                . ' WHERE (t.`text`=\'\' OR t.`text` IS NULL OR t.`needs_update`=1)'
+                . ' AND o.`lang_id` IS NULL';
         } else {
             // find all untranslated keys
             $sql .= ' WHERE (t.`text`=\'\' OR t.`text` IS NULL OR t.`needs_update`=1)';
@@ -324,6 +350,7 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
         if ($nrOfRecords > 0) {
             $sql .= ' LIMIT ' . $offset . ', ' . $nrOfRecords;
         }
+        #var_dump($sql);die;
         $res = $this->_dbo->query($sql, Msd_Db::ARRAY_ASSOC);
 
         return $res;
@@ -628,8 +655,18 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
      *
      * @return bool|string
      */
-    public function saveEntries($keyId, $newValues, $fallbackLanguageId = null, $ignoreSmallChange = false)
+    public function saveEntries($keyId, $newValues, $fallbackLanguageId = null, $ignoreSmallChange = false, $optionalTranslations = null)
     {
+
+        if($optionalTranslations == null) {
+            $optionalTranslations = array();
+            foreach($this->getOptionalTranslations($keyId) as $optionalTranslation) {
+                foreach($optionalTranslation as $optionalLanguage) {
+                    $optionalTranslations[] = $optionalLanguage;
+                }
+            }
+        }
+
         $keyId     = (int)$keyId;
         $oldValues = $this->getTranslationsByKeyId($keyId, array_keys($newValues), true);
         // remove unchanged languages
@@ -669,10 +706,18 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
         }
 
         if (!$ignoreSmallChange && $fallbackLanguageId != null && array_key_exists($fallbackLanguageId, $newValues)) {
+
             $sql = "UPDATE `{$this->_database}`.`{$this->_tableTranslations}` "
                 . "SET needs_update=1 "
                 . "WHERE `key_id`='{$keyId}' AND `lang_id` NOT IN (" . implode(',', $changedLanguageIds) . ")";
             $this->_dbo->query($sql);
+
+            if($optionalTranslations != null) {
+                $sql = "UPDATE `{$this->_database}`.`{$this->_tableTranslations}` "
+                    . "SET needs_update=0 "
+                    . "WHERE `key_id`='{$keyId}' AND `lang_id` IN (" . implode(',', $optionalTranslations) . ")";
+                $this->_dbo->query($sql);
+            }
         }
 
         $historyModel = new Application_Model_History();
@@ -819,19 +864,80 @@ class Application_Model_LanguageEntries extends Msd_Application_Model
     }
 
     /**
-     * Update the flag for certain language only
+     * updates the data for the optional translations
      *
-     * @param int $keyId        Id of the key.
-     * @param bool $value       Value of ind field.
-     *
-     * @return bool
+     * @param int $keyId      Id of the key.
+     * @param array $params   Parameters of the form submit
+     * @return array
      */
-    public function setOnlyCertainLanguageFlag($keyId, $value) {
-            $sql = "UPDATE `{$this->_database}`.`{$this->_tableKeys}` "
-                    . "SET `clf`='" . (int) $value . "' "
-                    . "WHERE `id`='$keyId';";
+    public function updateOptionalTranslations($keyId, $params) {
 
-            return (bool)$this->_dbo->query($sql, Msd_Db::SIMPLE);
+        $optional_translations = array();
+
+        $keys = array_keys($params);
+        $found_keys = preg_grep('/optional-\d/', $keys);
+
+        $sql = "DELETE FROM `{$this->_database}`.`{$this->_tableOptionalTranslations}` "
+            . "WHERE `key_id`='" . (int) $keyId . "';";
+        $this->_dbo->query($sql, Msd_Db::SIMPLE);
+
+        if(count($found_keys) > 0) {
+
+            foreach($found_keys as $found_key) {
+
+                $sql = "INSERT INTO `{$this->_database}`.`{$this->_tableOptionalTranslations}` "
+                    . "SET `lang_id`='" . (int) $params[$found_key] . "', "
+                    . "`key_id`='" . (int) $keyId . "'";
+                $this->_dbo->query($sql, Msd_Db::SIMPLE);
+
+                $optional_translations[] = $params[$found_key];
+            }
+            
+        }
+
+        return $optional_translations;
+    }
+
+    /**
+     * Gets the optional translations (all or either by id, languageIds or both)
+     *
+     * @param int $keyId           Id of the key.
+     * @param array $languageIds   Array of language ids
+     * @return array
+     */
+    public function getOptionalTranslations($keyId = null, $languageIds = null) {
+        $keyId  = (int)$keyId;
+        $ret = array();
+        if ($languageIds != null && !is_array($languageIds)) {
+            $languageIds = (array)$languageIds;
+        }
+
+        $sql       = 'SELECT `key_id`, `lang_id`'
+            . ' FROM `' . $this->_database . '`.`' . $this->_tableOptionalTranslations . '`';
+
+        if($keyId != null || $languageIds != null) {
+            $sql .= ' WHERE';
+        }
+        if($keyId != null) {
+            $sql .= ' `key_id`=' . $keyId;
+        }
+        if($languageIds != null) {
+            $languages = implode(',', $languageIds);
+            if($keyId != null) {
+                $sql .= ' AND';
+            }
+            $sql .= ' `lang_id` IN (' . $languages . ')';
+        }
+
+        $res       = $this->_dbo->query($sql, Msd_Db::ARRAY_ASSOC);
+        if (empty($res)) {
+            return array();
+        }
+        foreach ($res as $r) {
+            $ret[$r['key_id']][$r['lang_id']] = 1;
+        }
+
+        return $ret;
     }
 
 }

--- a/application/views/scripts/entries/edit.phtml
+++ b/application/views/scripts/entries/edit.phtml
@@ -19,7 +19,8 @@ $viewData = array(
     'needsUpdate'           => $this->needsUpdate,
     'fallbackLanguageId'    => $this->fallbackLanguageId,
     'useTranslationService'  => $this->useTranslationService,
-    'translationServiceName' => $this->translationServiceName,
+	'translationServiceName' => $this->translationServiceName,
+	'optionalTranslations'   => $this->optionalTranslations,
 );?>
 <div id="headline">
     <h2><?php echo $this->lang->L_EDIT_ENTRY;?></h2>

--- a/application/views/scripts/entries/edit/edit-languages.phtml
+++ b/application/views/scripts/entries/edit/edit-languages.phtml
@@ -3,7 +3,7 @@ $cycleHelper = $this->cycle(array('row-even', 'row-odd'));
 $entry = $this->entry;
 ?>
 <form action="<?php echo $this->baseUrl();?>/entries/edit/ref/<?php echo $this->referrer;?>" method="post" id="editForm">
-    <table class="bdr more-padding" summary="List of edit boxes">
+    <table class="bdr more-padding<?php echo (($this->key['clf']) ? ' untranslated-table' : null) ?>" summary="List of edit boxes">
         <tr class="thead"><th colspan="2"><?php echo $this->lang->L_EDIT;?>:</th></tr>
         <tr class="<?php echo $cycleHelper->next();?>">
             <td class="top"><?php echo $this->escape($this->lang->L_KEY);?>:</td>
@@ -22,6 +22,12 @@ $entry = $this->entry;
                         echo $this->assignedFileTemplate['name'] . ' (' . $this->assignedFileTemplate['filename'] . ')';
                     }
                 } ?>
+            </td>
+        </tr>
+        <tr class="<?php echo $cycleHelper->next()?>">
+            <td><?php echo $this->escape($this->lang->L_CLF); ?>:</td>
+            <td>
+                <input type="checkbox" name="clf"<?php echo (($this->key['clf']) ? ' checked' : null) ?>>
             </td>
         </tr>
         <?php
@@ -113,6 +119,9 @@ $entry = $this->entry;
                     <button type="submit" class="Formbutton ui-corner-all" id="saveGetUntranslated" name="saveGetUntranslated">
                         <?php echo $this->getIcon('save', $this->lang->L_SAVE) . ' ' . $this->lang->L_GET_NEXT_UNTRANSLATED_KEY;?>
                     </button><?php
+                }
+                if($this->key['ind']) {
+                    echo '<h3 class="clf-note">' . $this->lang->L_CLF_LONG . '</h3>';
                 }
                 ?>
             </td>

--- a/application/views/scripts/entries/edit/edit-languages.phtml
+++ b/application/views/scripts/entries/edit/edit-languages.phtml
@@ -3,7 +3,7 @@ $cycleHelper = $this->cycle(array('row-even', 'row-odd'));
 $entry = $this->entry;
 ?>
 <form action="<?php echo $this->baseUrl();?>/entries/edit/ref/<?php echo $this->referrer;?>" method="post" id="editForm">
-    <table class="bdr more-padding<?php echo (($this->key['clf']) ? ' untranslated-table' : null) ?>" summary="List of edit boxes">
+    <table class="bdr more-padding" summary="List of edit boxes">
         <tr class="thead"><th colspan="2"><?php echo $this->lang->L_EDIT;?>:</th></tr>
         <tr class="<?php echo $cycleHelper->next();?>">
             <td class="top"><?php echo $this->escape($this->lang->L_KEY);?>:</td>
@@ -22,12 +22,6 @@ $entry = $this->entry;
                         echo $this->assignedFileTemplate['name'] . ' (' . $this->assignedFileTemplate['filename'] . ')';
                     }
                 } ?>
-            </td>
-        </tr>
-        <tr class="<?php echo $cycleHelper->next()?>">
-            <td><?php echo $this->escape($this->lang->L_CLF); ?>:</td>
-            <td>
-                <input type="checkbox" name="clf"<?php echo (($this->key['clf']) ? ' checked' : null) ?>>
             </td>
         </tr>
         <?php
@@ -98,6 +92,12 @@ $entry = $this->entry;
                                     echo trim(htmlentities($entry[$languageId], ENT_COMPAT, 'utf-8'));
                                 };?></textarea>
                     <br /><br />
+                    <input type="checkbox" id="optional-<?php echo $this->languages[$languageId]['id'];?>"
+                           name="optional-<?php echo $this->languages[$languageId]['id'];?>"
+                           value="<?php echo $this->languages[$languageId]['id'];?>"
+                        <?php echo ((isset($this->optionalTranslations[$this->key['id']][$languageId])) ? ' checked' : null) ?>>
+                    <label for="optional-<?php echo $this->key['id'];?>-<?php echo $this->languages[$languageId]['id'];?>"><?php echo $this->lang->L_OPTIONAL_TRANSLATION; ?></label>
+                    <br />
                     <?php if ($languageId == $this->fallbackLanguageId) { ?>
                         <input type="checkbox" name="only-small-change" id="only-small-change" />
                         <label for="only-small-change"><?php echo $this->lang->L_ONLY_SMALL_CHANGE_INFO; ?></label>
@@ -119,9 +119,6 @@ $entry = $this->entry;
                     <button type="submit" class="Formbutton ui-corner-all" id="saveGetUntranslated" name="saveGetUntranslated">
                         <?php echo $this->getIcon('save', $this->lang->L_SAVE) . ' ' . $this->lang->L_GET_NEXT_UNTRANSLATED_KEY;?>
                     </button><?php
-                }
-                if($this->key['ind']) {
-                    echo '<h3 class="clf-note">' . $this->lang->L_CLF_LONG . '</h3>';
                 }
                 ?>
             </td>

--- a/application/views/scripts/entries/index.phtml
+++ b/application/views/scripts/entries/index.phtml
@@ -228,7 +228,11 @@ $fileTemplateHelper = $this->printFileTemplateHtml(
             foreach ($this->showLanguages as $lang) {
                 $text = isset($hit['languages'][$lang]) ? $hit['languages'][$lang] : '';
                 $text = htmlspecialchars($text, ENT_COMPAT,'utf-8');
-                if (!isset($text) || $text == '') {
+                    $isUntranslated = false;
+                    if ((!isset($text) || $text == '')) {
+                        if($hit['clf']) {
+                            $isUntranslated = true;
+                        }
                     $text = '<i>' . $this->lang->L_UNTRANSLATED . '</i>';
                 }
                 if (in_array($lang, $this->languagesEdit)) { ?>
@@ -237,7 +241,7 @@ $fileTemplateHelper = $this->printFileTemplateHtml(
                             <?php echo $this->getIcon('Edit', $this->lang->L_CLICK_TO_INLINE_EDIT);?>
                         </label>
                     </td>
-                    <td class="top">
+                    <td class="top<?php echo (($isUntranslated) ? ' untranslated' : null) ?>">
                         <?php if (array_key_exists('needsUpdate', $hit) && array_key_exists($lang, $hit['needsUpdate']) 
                             && $hit['needsUpdate'][$lang]) { ?>
                             <img src="<?php echo $this->getIconSrc('Attention', '16'); ?>"
@@ -257,7 +261,7 @@ $fileTemplateHelper = $this->printFileTemplateHtml(
                         $needsUpdateImage = $this->getIcon("Attention",  $this->lang->L_NEEDS_UPDATE_INFO, "16");
                     }
 
-                    echo '<td colspan="2" class="top">'. $needsUpdateImage . ' ' . $text .'</td>';
+                    echo '<td colspan="2" class="top' . (($isUntranslated) ? ' untranslated' : null) . '">'. $needsUpdateImage . ' ' . $text .'</td>';
                 }
             }
             ?>

--- a/application/views/scripts/entries/index.phtml
+++ b/application/views/scripts/entries/index.phtml
@@ -228,11 +228,7 @@ $fileTemplateHelper = $this->printFileTemplateHtml(
             foreach ($this->showLanguages as $lang) {
                 $text = isset($hit['languages'][$lang]) ? $hit['languages'][$lang] : '';
                 $text = htmlspecialchars($text, ENT_COMPAT,'utf-8');
-                    $isUntranslated = false;
                     if ((!isset($text) || $text == '')) {
-                        if($hit['clf']) {
-                            $isUntranslated = true;
-                        }
                     $text = '<i>' . $this->lang->L_UNTRANSLATED . '</i>';
                 }
                 if (in_array($lang, $this->languagesEdit)) { ?>
@@ -241,7 +237,7 @@ $fileTemplateHelper = $this->printFileTemplateHtml(
                             <?php echo $this->getIcon('Edit', $this->lang->L_CLICK_TO_INLINE_EDIT);?>
                         </label>
                     </td>
-                    <td class="top<?php echo (($isUntranslated) ? ' untranslated' : null) ?>">
+                    <td class="top<?php echo (($this->optionalTranslations[$keyId][$lang]) ? ' no-translation-needed' : null) ?>">
                         <?php if (array_key_exists('needsUpdate', $hit) && array_key_exists($lang, $hit['needsUpdate']) 
                             && $hit['needsUpdate'][$lang]) { ?>
                             <img src="<?php echo $this->getIconSrc('Attention', '16'); ?>"
@@ -285,6 +281,7 @@ $fileTemplateHelper = $this->printFileTemplateHtml(
     }
 ?>
 </table>
+<small class="dont-translate-notice"><?php echo $this->lang->L_OPTIONAL_TRANSLATION_LONG_DESC; ?></small>
 
 <div class="top-margin">
 <?php

--- a/docs/database/db_schema_update7.sql
+++ b/docs/database/db_schema_update7.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `optional_translations` (
+  `key_id` smallint(5) NOT NULL,
+  `lang_id` smallint(5) NOT NULL,
+  KEY `KEY ID` (`key_id`),
+  KEY `LANGUAGE ID` (`lang_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/public/css/otc/style.css
+++ b/public/css/otc/style.css
@@ -870,20 +870,15 @@ fieldset {
 .ui-selectmenu-status,
 .ui-selectmenu-menu ul { background:#F1F1F1 !important;}
 
-.untranslated {
+.no-translation-needed {
     background-color: #DDDDDD;
 }
 
-.untranslated span a {
+.no-translation-needed span a {
     color: #777777;
 }
 
-.untranslated-table thead, .untranslated-table .row-even, .untranslated-table .row-odd {
-    background-color: #DDDDDD;
-}
-
-.clf-note {
-    max-width: 580px;
-    padding: 5px;
-    text-align: center;
+.dont-translate-notice {
+    display: inline-block;
+    margin: 5px;
 }

--- a/public/css/otc/style.css
+++ b/public/css/otc/style.css
@@ -870,3 +870,20 @@ fieldset {
 .ui-selectmenu-status,
 .ui-selectmenu-menu ul { background:#F1F1F1 !important;}
 
+.untranslated {
+    background-color: #DDDDDD;
+}
+
+.untranslated span a {
+    color: #777777;
+}
+
+.untranslated-table thead, .untranslated-table .row-even, .untranslated-table .row-odd {
+    background-color: #DDDDDD;
+}
+
+.clf-note {
+    max-width: 580px;
+    padding: 5px;
+    text-align: center;
+}


### PR DESCRIPTION
As suggested yesterday here is the pull request for optional keys per language. The intention is to mark specific keys as "only for one language" so that the translators see that no translation is needed.

@DSB you have to add a boolean field 'clf' to the keys table to make it functionable :)
